### PR TITLE
update supervisor config after update.

### DIFF
--- a/deploy/update_plone
+++ b/deploy/update_plone
@@ -55,6 +55,7 @@ def update_plone(oldrev, newrev):
     else:
         restart_load_balanced_instances()
 
+    update_supervisor_config()
     recook_resources()
     maybe_start('instancepub')
 
@@ -208,6 +209,59 @@ def has_proposed_upgrades():
 def recook_resources():
     for site in get_sites():
         run_fg('bin/upgrade recook -s %s' % site['path'])
+
+
+def update_supervisor_config():
+    """
+    "./bin/supervisorctl reread" has output when the supervisor configuration
+    has changed, e.g.:
+    $ ./bin/supervisorctl reread
+    instance1: changed
+    redis: available
+
+    For updating the supervisor daemon with the new settings, use the "update"
+    action:
+    $ ./bin/supervisorctl update instance1
+    instance1: stopped
+    instance1: updated process group
+
+    As this does restart the programs, we do not want to do it for all programs
+    (not for zeo, for example) and we do not want to stop all programs at once.
+    We also do it at the end of the update as we might already have updated
+    programs earlier when restarting them.
+    """
+
+    blacklist = (
+        # Do not restart "zeo" automatically as it may result in
+        # an unexpected downtime.
+        'zeo',
+    )
+
+    print ''
+    print ''
+    print ''
+    updates = run_bg('bin/supervisorctl reread')
+    print 'Supervisor configuration reread: ', updates
+    LOG.info('Supervisor configuration reread: {0}'.format(updates))
+
+    if ':' not in updates:
+        # No config updates to processes
+        return
+
+    for line in updates.strip().splitlines():
+        program, state = line.strip().split(': ', 1)
+        if program in blacklist:
+            msg = ('Changes on program "{0}" are not automatically updated'
+                   ' because the program is blacklisted.'
+                   ' Manual action is necessary!').format(program)
+            LOG.warning(msg)
+            print '-' * 30
+            print 'WARNING:', msg
+            print '-' * 30
+            continue
+
+        print 'Updating {0} ({1})'.format(program, state)
+        run_fg('bin/supervisorctl update {0}'.format(program))
 
 
 def get_sites():


### PR DESCRIPTION
When buildout is ran, the supervisor.cfg may change. These changes need to be loaded by the supervisor daemon.

There are two commands involved:

1. "bin/supervisorctl reread" tells us whether there are changes and
   what the changes are (e.g. program changed, added, removed).
2. "bin/supervisorctl update [programs..]" updates one, many or all
   programs, usually by restarting the program.

When we do a reread / update right after running buildout, it will probably restart all instances at once, which violates the zero downtime strategy. Therefore before ich "start" of a program, the program is updated. At the end of the deployment most programs will already be updated, but untracked programs are not and new programs are not loaded.

In order to update all program changes we reread at the end of the deployment and then update the changed programs one after another. This may restart changed programs, it will start new programs and it will shutdown removed programs.

However, we do never restart the zeo because this may result in connection loss of the instances and this violates the zero downtime strategy. This problem cannot be solved automatically and the maintainer must restart the zeo at the right time (maintenance window).

// @maethu @mbaechtold 