### PR TITLE
Zero downtime by pushing to branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,3 +184,18 @@ extends =
 
 deployment-zero-downtime = true
 ```
+
+**Deploy one commit with zero downtime**
+
+When deploying a commit with upgrade steps, the site will be taken offline
+unless zero downtime is configured.
+But sometimes we want to deploy a commit with (fast) upgrades to a
+non-zero-downtime deployment, but without downtime.
+For marking a commit as "zero-downtime proof", you can push it to the branch
+`zero-downtime` on the deployment remote, before doing a regular deployment.
+
+Example:
+```sh
+$ git push testing master:zero-downtime
+$ git push testing master
+```

--- a/deploy/update_plone
+++ b/deploy/update_plone
@@ -16,7 +16,7 @@ LOG = logging.getLogger('update_plone')
 
 
 def update_plone(oldrev, newrev):
-    zero_downtime = is_zero_downtime_configured()
+    zero_downtime = is_zero_downtime_configured(newrev)
     print 'UPDATE PLONE'
     print '${0} -> ${1}'.format(oldrev, newrev)
 
@@ -307,16 +307,24 @@ def setup_logging():
     logger.addHandler(handler)
 
 
-def is_zero_downtime_configured():
+def is_zero_downtime_configured(newrev):
     # The zero downtime configuration must be in the buildout.cfg (may be a
     # symlink) but cannot be in an "extends" since those are not followed!
     parser = ConfigParser.SafeConfigParser()
     parser.read('buildout.cfg')
     option = ('buildout', 'deployment-zero-downtime')
-    if not parser.has_option(*option):
-        return False
-    truthy = ('y', 'yes', 't', 'true', 'on', '1')
-    return parser.get(*option).strip().lower() in truthy
+    if parser.has_option(*option):
+        truthy = ('y', 'yes', 't', 'true', 'on', '1')
+        if parser.get(*option).strip().lower() in truthy:
+            return True
+
+    # Maybe there is a branch "zero-downtime".
+    # When there is one, and it contains our target rev, it save
+    # to update update in zero downtime mode.
+    branches_with_rev = map(
+        lambda line: re.sub('^\* ', '', line.strip()),
+        run_bg('git branch --contains {0}'.format(newrev)).splitlines())
+    return 'zero-downtime' in branches_with_rev
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When deploying a commit with upgrade steps, the site will be taken offline unless zero downtime is configured.
But sometimes we want to deploy a commit with (fast) upgrades to a non-zero-downtime deployment, but without downtime.
For marking a commit as "zero-downtime proof", you can push it to the branch `zero-downtime` on the deployment remote, before doing a regular deployment.