### PR TITLE
Install revealed upgrades.

### DIFF
--- a/deploy/update_plone
+++ b/deploy/update_plone
@@ -95,6 +95,10 @@ def update_plone(oldrev, newrev, force=False):
             run_plone_upgrades()
         if proposed_upgrades:
             run_upgrades()
+            # If the installed upgrades revealed new proposed upgrades,
+            # we want to install them now too.
+            if has_proposed_upgrades():
+                run_upgrades()
 
         restart_load_balanced_instances()
     else:


### PR DESCRIPTION
If upgrades have the effect that new upgrades appear or are proposed, we should install those new upgrades too.

For example when an upgrade sets the installed-version of another profile which also provide upgrades, this will install those upgrades too.